### PR TITLE
Add executions to spring boot plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,7 @@
         <java.version>11</java.version>
         <spring.boot.version>2.6.4</spring.boot.version>
 
-        <main.class>uk.gov.companieshouse.disqualifiedofficers.search.DisqualifiedOfficersSearchConsumerApplication
-        </main.class>
+
 
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <kafka-models.version>1.0.27</kafka-models.version>
@@ -82,6 +81,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This PR adds an executions block to the spring boot maven plugin section of the pom. This is to stop no main manifest errors when running the jar.