### PR TITLE
Consume resource changed kafka topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ target/
 *.zip
 *.tar.gz
 *.rar
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build:
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
 .PHONY: test
-test: test-unit
+test: test-unit test-integration
 
 .PHONY: test-unit
 test-unit: clean

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ test: test-unit
 test-unit: clean
 	mvn test
 
+
+.PHONY: test-integration
+test-integration:
+	mvn integration-test -Dskip.unit.tests=true failsafe:verify
+
 .PHONY: package
 package:
 ifndef version

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
-        <artifactId>companies-house-parent</artifactId>
-        <version>1.3.1</version>
+        <artifactId>companies-house-spring-boot-parent</artifactId>
+        <version>1.5.0-rc1</version>
     </parent>
 
     <artifactId>disqualified-officers-search-consumer</artifactId>
@@ -17,11 +17,18 @@
         <java.version>11</java.version>
         <spring.boot.version>2.6.4</spring.boot.version>
 
+        <main.class>uk.gov.companieshouse.disqualifiedofficers.search.DisqualifiedOfficersSearchConsumerApplication</main.class>
 
-
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-build-helper-plugin.version>3.2.0</maven-build-helper-plugin.version>
         <kafka-models.version>1.0.27</kafka-models.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
+        <structured-logging.version>1.9.12</structured-logging.version>
+        <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
+        <test-containers.version>1.16.2</test-containers.version>
+        <maven-failsafe-plugin.version>2.12.4</maven-failsafe-plugin.version>
 
         <!-- Docker -->
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>
@@ -31,26 +38,57 @@
             ${project.basedir}/target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
+        <skip.integration.tests>false</skip.integration.tests>
+        <skip.unit.tests>false</skip.unit.tests>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${spring.boot.version}</version>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${test-containers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${test-containers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${test-containers.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!--kafka -->
@@ -65,6 +103,18 @@
             <artifactId>ch-kafka</artifactId>
             <version>${ch-kafka.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>structured-logging</artifactId>
+            <version>${structured-logging.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -72,15 +122,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>${main.class}</mainClass>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -91,26 +140,126 @@
             </plugin>
 
             <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>${jib-maven-plugin.version}</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution model. -->
+                            <destFile>${sonar.jacoco.reports}/jacoco.exec</destFile>
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${sonar.jacoco.reports}/jacoco.exec</dataFile>
+                            <outputDirectory>${sonar.jacoco.reports}/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution model. -->
+                            <destFile>${sonar.jacoco.reports}/jacoco-it.exec</destFile>
+                            <propertyName>failsafeArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${sonar.jacoco.reports}/jacoco-it.exec</dataFile>
+                            <outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${maven-build-helper-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/itest/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <excludes>
+                        <exclude>**/*ITest.java</exclude>
+                    </excludes>
+                    <skipTests>${skip.unit.tests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                    <skipITs>${skip.integration.tests}</skipITs>
+                    <includes>
+                        <include>**/*ITest.java</include>
+                    </includes>
+                </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib-maven-plugin.version}</version>
+                <configuration>
+                    <container>
+                        <expandClasspathDependencies>true</expandClasspathDependencies>
+                    </container>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${sonar-maven-plugin.version}</version>
             </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <structured-logging.version>1.9.12</structured-logging.version>
         <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
         <test-containers.version>1.16.2</test-containers.version>
-        <maven-failsafe-plugin.version>2.12.4</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 
         <!-- Docker -->
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/config/KafkaTestContainerConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/config/KafkaTestContainerConfig.java
@@ -1,0 +1,83 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+import uk.gov.companieshouse.disqualifiedofficers.search.serialization.ResourceChangedDeserializer;
+import uk.gov.companieshouse.disqualifiedofficers.search.serialization.ResourceChangedSerializer;
+import uk.gov.companieshouse.kafka.producer.CHKafkaProducer;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+@TestConfiguration
+public class KafkaTestContainerConfig {
+
+    @MockBean
+    private CHKafkaProducer chKafkaProducer;
+
+    private final ResourceChangedDeserializer resourceChangedDeserializer;
+
+    @Autowired
+    public KafkaTestContainerConfig(ResourceChangedDeserializer resourceChangedDeserializer) {
+        this.resourceChangedDeserializer = resourceChangedDeserializer;
+    }
+
+    @Bean
+    public KafkaContainer kafkaContainer() {
+        KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
+        kafkaContainer.start();
+        return kafkaContainer;
+    }
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, ResourceChangedData> listenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ResourceChangedData> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(kafkaConsumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, ResourceChangedData> kafkaConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(kafkaContainer()),
+                new StringDeserializer(),
+                resourceChangedDeserializer);
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigs(KafkaContainer kafkaContainer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "disqualified-officer-search-consumer");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ResourceChangedDeserializer.class);
+        return props;
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory(KafkaContainer kafkaContainer) {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ResourceChangedSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory(kafkaContainer()));
+    }
+
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/DisqualifiedOfficerSearchConsumerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/DisqualifiedOfficerSearchConsumerITest.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.consumer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.companieshouse.disqualifiedofficers.search.config.KafkaTestContainerConfig;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+import java.io.IOException;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext
+@Import(KafkaTestContainerConfig.class)
+@ActiveProfiles({"test"})
+public class DisqualifiedOfficerSearchConsumerITest {
+
+    @Autowired
+    public KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${disqualified-officers.search.topic.main}")
+    private String mainTopic;
+
+    private TestData testData = new TestData();
+
+    @Test
+    void testSendingKafkaMessage() throws IOException {
+        ResourceChangedData resourceChanged = testData.
+                getResourceChangedData("natural_disqualification.json");
+
+        kafkaTemplate.send(mainTopic, resourceChanged);
+    }
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/TestData.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/TestData.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.consumer;
+
+import org.springframework.util.FileCopyUtils;
+import uk.gov.companieshouse.stream.EventRecord;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class TestData {
+
+    public static final String CHANGED = "changed";
+    public static final String CONTEXT_ID = "context_id";
+    public static final String RESOURCE_ID = "12345678";
+    public static final String RESOURCE_KIND = "disqualified-officers";
+    public static final String CHARGES_RESOURCE_URI = "/disqualified-officers/12345678";
+
+    public ResourceChangedData getResourceChangedData(String fileName) throws IOException {
+        EventRecord event = EventRecord.newBuilder()
+                .setType(CHANGED)
+                .setPublishedAt("2022-02-22T10:51:30")
+                .setFieldsChanged(Arrays.asList("foo", "moo"))
+                .build();
+
+        String disqOfficerData = getDisqOfficerData(fileName);
+
+        return createResourceChangedData(event, disqOfficerData);
+    }
+
+    private ResourceChangedData createResourceChangedData(EventRecord event, String chargesData) {
+        return ResourceChangedData.newBuilder()
+                .setContextId(CONTEXT_ID)
+                .setResourceId(RESOURCE_ID)
+                .setResourceKind(RESOURCE_KIND)
+                .setResourceUri(CHARGES_RESOURCE_URI)
+                .setData(chargesData)
+                .setEvent(event)
+                .build();
+    }
+
+    private String getDisqOfficerData(String filename) throws IOException {
+        InputStreamReader exampleChargesJsonPayload = new InputStreamReader(
+                Objects.requireNonNull(ClassLoader.getSystemClassLoader()
+                        .getResourceAsStream(filename)));
+        return FileCopyUtils.copyToString(exampleChargesJsonPayload);
+    }
+
+}

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/TestData.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/TestData.java
@@ -15,7 +15,7 @@ public class TestData {
     public static final String CONTEXT_ID = "context_id";
     public static final String RESOURCE_ID = "12345678";
     public static final String RESOURCE_KIND = "disqualified-officers";
-    public static final String CHARGES_RESOURCE_URI = "/disqualified-officers/12345678";
+    public static final String CHARGES_RESOURCE_URI = "/disqualified-officers/natural/12345678";
 
     public ResourceChangedData getResourceChangedData(String fileName) throws IOException {
         EventRecord event = EventRecord.newBuilder()
@@ -29,22 +29,22 @@ public class TestData {
         return createResourceChangedData(event, disqOfficerData);
     }
 
-    private ResourceChangedData createResourceChangedData(EventRecord event, String chargesData) {
+    private ResourceChangedData createResourceChangedData(EventRecord event, String disqOfficerData) {
         return ResourceChangedData.newBuilder()
                 .setContextId(CONTEXT_ID)
                 .setResourceId(RESOURCE_ID)
                 .setResourceKind(RESOURCE_KIND)
                 .setResourceUri(CHARGES_RESOURCE_URI)
-                .setData(chargesData)
+                .setData(disqOfficerData)
                 .setEvent(event)
                 .build();
     }
 
     private String getDisqOfficerData(String filename) throws IOException {
-        InputStreamReader exampleChargesJsonPayload = new InputStreamReader(
+        InputStreamReader exampleDisqOfficerJsonPayload = new InputStreamReader(
                 Objects.requireNonNull(ClassLoader.getSystemClassLoader()
                         .getResourceAsStream(filename)));
-        return FileCopyUtils.copyToString(exampleChargesJsonPayload);
+        return FileCopyUtils.copyToString(exampleDisqOfficerJsonPayload);
     }
 
 }

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/controller/HealthCheckControllerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/controller/HealthCheckControllerITest.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class HealthCheckControllerITest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Successfully returns health status")
+    void returnHealthStatusSuccessfully() throws Exception {
+        mockMvc.perform(get("/healthcheck")).andExpect(status().isOk());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/config/KafkaConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/config/KafkaConfig.java
@@ -1,0 +1,111 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import uk.gov.companieshouse.disqualifiedofficers.search.serialization.ResourceChangedDeserializer;
+import uk.gov.companieshouse.disqualifiedofficers.search.serialization.ResourceChangedSerializer;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+@Configuration
+@EnableKafka
+@Profile("!test")
+public class KafkaConfig {
+
+
+    private final ResourceChangedDeserializer resourceChangedDeserializer;
+    private final ResourceChangedSerializer resourceChangedSerializer;
+
+    private final String bootstrapServers;
+
+    /**
+     * Constructor.
+     */
+    public KafkaConfig(ResourceChangedDeserializer resourceChangedDeserializer,
+                       ResourceChangedSerializer resourceChangedSerializer,
+                       @Value("${spring.kafka.bootstrap-servers}") String bootstrapServers) {
+        this.resourceChangedDeserializer = resourceChangedDeserializer;
+        this.resourceChangedSerializer = resourceChangedSerializer;
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    /**
+     * Kafka Consumer Factory.
+     */
+    @Bean
+    public ConsumerFactory<String, ResourceChangedData> kafkaConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(resourceChangedDeserializer));
+    }
+
+    /**
+     * Kafka Producer Factory.
+     */
+    @Bean
+    public ProducerFactory<String, ResourceChangedData> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                ResourceChangedDeserializer.class);
+        return new DefaultKafkaProducerFactory<>(
+                props, new StringSerializer(), resourceChangedSerializer);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ResourceChangedData> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    /**
+     * Kafka Listener Container Factory.
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory
+            <String, ResourceChangedData> listenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ResourceChangedData> factory
+                = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(kafkaConsumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+
+        return factory;
+    }
+
+    private Map<String, Object> consumerConfigs() {
+        Map<String, Object> props = new HashMap<>();
+
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS,
+                ResourceChangedDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+
+        return props;
+    }
+}
+
+
+
+
+

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/config/LoggingConfig.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/config/LoggingConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Configuration class for logging.
+ */
+@Configuration
+public class LoggingConfig {
+
+    @Value("${logger.namespace}")
+    private String loggerNamespace;
+
+    /**
+     * Main application logger with component specific namespace.
+     *
+     * @return the {@link LoggerFactory} for the specified namespace
+     */
+    @Bean
+    public Logger logger() {
+        return LoggerFactory.getLogger(loggerNamespace);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/DisqualifiedOfficersSearchConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/consumer/DisqualifiedOfficersSearchConsumer.java
@@ -1,0 +1,38 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.consumer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.Message;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+
+public class DisqualifiedOfficersSearchConsumer {
+
+    @Autowired
+    private Logger logger;
+
+    /**
+     * Receives Main topic messages.
+     */
+    @KafkaListener(id = "${disqualified-officers.search.main-id}",
+            topics = "${disqualified-officers.search.topic.main}",
+            groupId = "${disqualified-officers.search.group-id}",
+            containerFactory = "listenerContainerFactory")
+    public void receiveMainMessages(Message<ResourceChangedData> message) {
+        logger.info("A new message read from MAIN topic with payload: "
+                + message.getPayload());
+    }
+
+    /**
+     * Receives Retry topic messages.
+     */
+    @KafkaListener(id = "${disqualified-officers.search.retry-id}",
+            topics = "${disqualified-officers.search.topic.retry}",
+            groupId = "${disqualified-officers.search.group-id}",
+            containerFactory = "listenerContainerFactory")
+    public void receiveRetryMessages(Message<ResourceChangedData> message) {
+        logger.info(String.format("A new message read from RETRY topic with payload:%s "
+                + "and headers:%s ", message.getPayload(), message.getHeaders()));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/controller/HealthCheckController.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/controller/HealthCheckController.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.companieshouse.logging.Logger;
+
+@RestController
+public class HealthCheckController {
+
+    @Autowired
+    private Logger logger;
+
+    @GetMapping("/healthcheck")
+    public ResponseEntity<Void> healthcheck() {
+        logger.info("Healthcheck endpoint called");
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedDeserializer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedDeserializer.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.serialization;
+
+import java.util.Arrays;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+@Component
+public class ResourceChangedDeserializer implements Deserializer<ResourceChangedData> {
+
+    @Override
+    public ResourceChangedData deserialize(String topic, byte[] data) {
+        try {
+            Decoder decoder = DecoderFactory.get().binaryDecoder(data, null);
+            DatumReader<ResourceChangedData> reader = new ReflectDatumReader<>(ResourceChangedData.class);
+            return reader.read(null, decoder);
+        } catch (Exception ex) {
+            throw new SerializationException(
+                    "Message data [" + Arrays.toString(data) + "] from topic [" + topic + "] "
+                            + "cannot be deserialized", ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializer.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.serialization;
+
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.errors.SerializationException;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.kafka.serialization.AvroSerializer;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+@Component
+public class ResourceChangedSerializer implements Serializer<ResourceChangedData> {
+
+    @Override
+    public byte[] serialize(String topic, ResourceChangedData payload) {
+
+        try {
+            if (payload == null) {
+                return null;
+            }
+            DatumWriter<ResourceChangedData> writer = new SpecificDatumWriter<>();
+            EncoderFactory encoderFactory = EncoderFactory.get();
+
+            AvroSerializer<ResourceChangedData> avroSerializer =
+                    new AvroSerializer<>(writer, encoderFactory);
+
+            return avroSerializer.toBinary(payload);
+        } catch (Exception ex) {
+            throw new SerializationException("Serialization exception while "
+                    + "writing to byte array", ex);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-management.endpoints.web.base-path=/disqualified-officers-search-consumer/
-management.endpoints.web.path-mapping.health=healthcheck

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+management:
+  endpoints:
+    web:
+      base-path: /disqualified-officers-search-consumer
+      path-mapping:
+        health: /healthcheck
+
+server:
+  port: 8081
+
+springfox:
+  documentation:
+    auto-startup: false
+
+spring:
+  kafka:
+    bootstrap-servers: ${STREAMING_KAFKA_BROKER_URL:localhost:29092}
+
+disqualified-officers:
+  search:
+    group-id: disqualified-officers-search-consumer
+    main-id: disqualified-officers-main-search-consumer
+    retry-id: disqualified-officers-retry-search-consumer
+    topic:
+      main: stream-disqualifications
+      retry: stream-disqualifications-retry
+
+logger:
+  namespace: disqualified-officers-search-consumer

--- a/src/main/resources/natural_disqualification.json
+++ b/src/main/resources/natural_disqualification.json
@@ -1,0 +1,57 @@
+{
+  "date_of_birth": "2000-02-18",
+  "disqualifications" : [
+    {
+      "case_identifier" : "INV3975227",
+      "address": {
+        "premise": "3000",
+        "address_line_1": "SYLVESTERucy AVENUE",
+        "address_line_2": "Skewen",
+        "locality": "Neath",
+        "region": "",
+        "country": "Wales",
+        "postal_code": "SA10 6RR"
+      },
+      "company_names" : [
+        "CONSORTIUM TECHNOLOGY LIMITED"
+      ],
+      "court_name" : "Insolvency Service",
+      "disqualification_type" : "court-order",
+      "disqualified_from" : "2015-02-18",
+      "disqualified_until" : "2025-02-17",
+      "heard_on" : "2018-02-14",
+      "undertaken_on" : null,
+      "last_variation":{
+        "varied_on" : "2021-02-17",
+        "case_identifier" : "1",
+        "court_name" : "SWINDLERS"
+      },
+      "reason" : {
+        "act" : "company-directors-disqualification-northern-ireland-order-2002",
+        "description_identifier":"order-disqualifying-a-person-instructing-an-unfit-director-of-an-insolvent-company",
+        "article":"11A"
+      }
+    }
+  ],
+  "etag": "string",
+  "forename": "string",
+  "honours": "string",
+  "kind": "string",
+  "links": {
+    "self": "string"
+  },
+  "nationality": "string",
+  "other_forenames": "string",
+  "permissions_to_act": [
+    {
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "expires_on": "2015-02-18",
+      "granted_on": "2025-02-17"
+    }
+  ],
+  "surname": "string",
+  "title": "string"
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedDeserializerTest.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.serialization;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.stream.ResourceChangedData;
+import uk.gov.companieshouse.stream.EventRecord;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceChangedDeserializerTest {
+
+    private ResourceChangedDeserializer deserializer;
+
+    @BeforeEach
+    public void init() {
+        deserializer = new ResourceChangedDeserializer();
+    }
+
+    @Test
+    void When_deserialize_Expect_ValidResourceChangedDataObject() {
+
+        EventRecord eventRecord = new EventRecord("published_at", "type", List.of("fields_changed"));
+        ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind",
+                "resource_uri", "context_id", "resource_id", "data", eventRecord);
+        byte[] data = encodedData(resourceChangedData);
+
+        ResourceChangedData deserializedObject = deserializer.deserialize("", data);
+
+        assertThat(deserializedObject).isEqualTo(resourceChangedData);
+
+    }
+
+    @Test
+    void When_deserializeFails_throwsNonRetryableError() {
+        byte[] data = "Invalid message".getBytes();
+        assertThrows(SerializationException.class, () -> deserializer.deserialize("", data));
+    }
+
+    private byte[] encodedData(ResourceChangedData resourceChangedData) {
+        ResourceChangedSerializer serializer = new ResourceChangedSerializer();
+        return serializer.serialize("", resourceChangedData);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedDeserializerTest.java
@@ -19,6 +19,13 @@ class ResourceChangedDeserializerTest {
 
     private ResourceChangedDeserializer deserializer;
 
+    private static final byte[] serialized = {26, 114, 101, 115, 111, 117, 114, 99, 101, 95, 107,
+            105, 110, 100, 24, 114, 101, 115, 111, 117, 114, 99, 101, 95, 117, 114, 105, 20, 99,
+            111, 110, 116, 101, 120, 116, 95, 105, 100, 22, 114, 101, 115, 111, 117, 114, 99, 101,
+            95, 105, 100, 8, 100, 97, 116, 97, 24, 112, 117, 98, 108, 105, 115, 104, 101, 100, 95,
+            97, 116, 8, 116, 121, 112, 101, 2, 2, 28, 102, 105, 101, 108, 100, 115, 95, 99, 104,
+            97, 110, 103, 101, 100, 0};
+
     @BeforeEach
     public void init() {
         deserializer = new ResourceChangedDeserializer();
@@ -30,22 +37,16 @@ class ResourceChangedDeserializerTest {
         EventRecord eventRecord = new EventRecord("published_at", "type", List.of("fields_changed"));
         ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind",
                 "resource_uri", "context_id", "resource_id", "data", eventRecord);
-        byte[] data = encodedData(resourceChangedData);
 
-        ResourceChangedData deserializedObject = deserializer.deserialize("", data);
+        ResourceChangedData deserializedObject = deserializer.deserialize("", serialized);
 
         assertThat(deserializedObject).isEqualTo(resourceChangedData);
 
     }
 
     @Test
-    void When_deserializeFails_throwsNonRetryableError() {
+    void When_deserializeFails_throwsSerializationError() {
         byte[] data = "Invalid message".getBytes();
         assertThrows(SerializationException.class, () -> deserializer.deserialize("", data));
-    }
-
-    private byte[] encodedData(ResourceChangedData resourceChangedData) {
-        ResourceChangedSerializer serializer = new ResourceChangedSerializer();
-        return serializer.serialize("", resourceChangedData);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
@@ -14,6 +14,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 public class ResourceChangedSerializerTest {
 
+    private static final byte[] expected = {26, 114, 101, 115, 111, 117, 114, 99, 101, 95, 107,
+            105, 110, 100, 24, 114, 101, 115, 111, 117, 114, 99, 101, 95, 117, 114, 105, 20, 99,
+            111, 110, 116, 101, 120, 116, 95, 105, 100, 22, 114, 101, 115, 111, 117, 114, 99, 101,
+            95, 105, 100, 8, 100, 97, 116, 97, 24, 112, 117, 98, 108, 105, 115, 104, 101, 100, 95,
+            97, 116, 8, 116, 121, 112, 101, 2, 2, 28, 102, 105, 101, 108, 100, 115, 95, 99, 104,
+            97, 110, 103, 101, 100, 0};
+
     private ResourceChangedSerializer serializer;
 
     @BeforeEach
@@ -22,23 +29,19 @@ public class ResourceChangedSerializerTest {
     }
 
     @Test
-    void When_serialize_Expect_chsDeltaBytes() {
+    void When_serialize_Expect_chsDeltaBytes() throws Exception {
         EventRecord eventRecord = new EventRecord("published_at", "type", List.of("fields_changed"));
-        ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind", "resource_uri", "context_id", "resource_id", "data", eventRecord );
+        ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind",
+                "resource_uri", "context_id", "resource_id", "data", eventRecord );
 
         byte[] result = serializer.serialize("", resourceChangedData);
 
-        assertThat(decodedData(result)).isEqualTo(resourceChangedData);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
     void When_serialize_null_returns_null() {
         byte[] serialize = serializer.serialize("", null);
         assertThat(serialize).isEqualTo(null);
-    }
-
-    private ResourceChangedData decodedData(byte[] chsDelta) {
-        ResourceChangedDeserializer serializer = new ResourceChangedDeserializer();
-        return serializer.deserialize("", chsDelta);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.serialization;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.stream.EventRecord;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class ResourceChangedSerializerTest {
+
+    private ResourceChangedSerializer serializer;
+
+    @BeforeEach
+    public void init() {
+        serializer = new ResourceChangedSerializer();
+    }
+
+    @Test
+    void When_serialize_Expect_chsDeltaBytes() {
+        EventRecord eventRecord = new EventRecord("published_at", "type", List.of("fields_changed"));
+        ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind", "resource_uri", "context_id", "resource_id", "data", eventRecord );
+
+        byte[] result = serializer.serialize("", resourceChangedData);
+
+        assertThat(decodedData(result)).isEqualTo(resourceChangedData);
+    }
+
+    @Test
+    void When_serialize_null_returns_null() {
+        byte[] serialize = serializer.serialize("", null);
+        assertThat(serialize).isEqualTo(null);
+    }
+
+    private ResourceChangedData decodedData(byte[] chsDelta) {
+        ResourceChangedDeserializer serializer = new ResourceChangedDeserializer();
+        return serializer.deserialize("", chsDelta);
+    }
+}


### PR DESCRIPTION
This pr adds initial code to the disqualified officers search consumer to consume resource changed kafka topics from the streaming service. Also included are integration tests.

**Resolves:**
- DSND-692