### PR TITLE
Create elastic search transformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <kafka-models.version>1.0.27</kafka-models.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
-        <private-api-sdk-java.version>2.0.146</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.159</private-api-sdk-java.version>
         <test-containers.version>1.16.2</test-containers.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <kafka-models.version>1.0.27</kafka-models.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
-        <private-api-sdk-java.version>2.0.159</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.162</private-api-sdk-java.version>
         <test-containers.version>1.16.2</test-containers.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/model/CompanyName.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/model/CompanyName.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.model;
+
+public class CompanyName {
+
+    private String name;
+    private String ending;
+
+    public CompanyName(String name, String ending) {
+        this.name = name;
+        this.ending = ending;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEnding() {
+        return ending;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/model/StreamData.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/model/StreamData.java
@@ -1,0 +1,179 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.DisqualificationLinks;
+import uk.gov.companieshouse.api.disqualification.PermissionToAct;
+
+import java.util.List;
+
+public class StreamData {
+
+    // Common properties
+    @JsonProperty("disqualifications")
+    private List<Disqualification> disqualifications;
+
+    @JsonProperty("etag")
+    private String etag;
+
+    @JsonProperty("permissions_to_act")
+    private List<PermissionToAct> permissionsToAct;
+
+    @JsonProperty("kind")
+    private String kind;
+
+    @JsonProperty("links")
+    private DisqualificationLinks links;
+
+    // Natural properties
+    @JsonProperty("date_of_birth")
+    private String dateOfBirth;
+
+    @JsonProperty("forename")
+    private String forename;
+
+    @JsonProperty("honours")
+    private String honours;
+
+    @JsonProperty("nationality")
+    private String nationality;
+
+    @JsonProperty("other_forenames")
+    private String otherForenames;
+
+    @JsonProperty("surname")
+    private String surname;
+
+    @JsonProperty("title")
+    private String title;
+
+    // Corporate properties
+    @JsonProperty("company_number")
+    private String companyNumber;
+
+    @JsonProperty("country_of_registration")
+    private String countryOfRegistraition;
+
+    @JsonProperty("name")
+    private String name;
+
+    public List<Disqualification> getDisqualifications() {
+        return disqualifications;
+    }
+
+    public String getEtag() {
+        return etag;
+    }
+
+    public List<PermissionToAct> getPermissionsToAct() {
+        return permissionsToAct;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public DisqualificationLinks getLinks() {
+        return links;
+    }
+
+    public String getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public String getForename() {
+        return forename;
+    }
+
+    public String getHonours() {
+        return honours;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public String getOtherForenames() {
+        return otherForenames;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public String getCountryOfRegistraition() {
+        return countryOfRegistraition;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setDisqualifications(List<Disqualification> disqualifications) {
+        this.disqualifications = disqualifications;
+    }
+
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+
+    public void setPermissionsToAct(List<PermissionToAct> permissionsToAct) {
+        this.permissionsToAct = permissionsToAct;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public void setLinks(DisqualificationLinks links) {
+        this.links = links;
+    }
+
+    public void setDateOfBirth(String dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public void setForename(String forename) {
+        this.forename = forename;
+    }
+
+    public void setHonours(String honours) {
+        this.honours = honours;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public void setOtherForenames(String otherForenames) {
+        this.otherForenames = otherForenames;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public void setCountryOfRegistraition(String countryOfRegistraition) {
+        this.countryOfRegistraition = countryOfRegistraition;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.processor;
+
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+@Component
+public class ResourceChangedProcessor {
+
+    public void processResourceChanged(Message<ResourceChangedData> message) {
+        ResourceChangedData payload = message.getPayload();
+
+        Object elasticSearchData = transformer.getDataFromPayload(payload);
+
+        apiService.sendElasticSearchData(elasticSearchData);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
@@ -1,17 +1,24 @@
 package uk.gov.companieshouse.disqualifiedofficers.search.processor;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.disqualifiedofficers.search.transformer.ElasticSearchTransformer;
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @Component
 public class ResourceChangedProcessor {
 
+    @Autowired
+    private ElasticSearchTransformer transformer;
+
     public void processResourceChanged(Message<ResourceChangedData> message) {
         ResourceChangedData payload = message.getPayload();
 
-        Object elasticSearchData = transformer.getDataFromPayload(payload);
+        OfficerDisqualification elasticSearchData = transformer
+                .getOfficerDisqualificationFromResourceChanged(payload);
 
-        apiService.sendElasticSearchData(elasticSearchData);
+        //apiService.sendElasticSearchData(elasticSearchData);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformer.java
@@ -1,0 +1,50 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.transformer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.CompanyName;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.StreamData;
+import uk.gov.companieshouse.disqualifiedofficers.search.utils.AddressUtils;
+import uk.gov.companieshouse.disqualifiedofficers.search.utils.CompanyNameUtils;
+import uk.gov.companieshouse.disqualifiedofficers.search.utils.DisqualifiedPersonName;
+
+@Component
+public class DisqualificationItemTransformer {
+
+    private static final String recordType = "disqualifications";
+
+    @Autowired
+    private AddressUtils addressUtils;
+    @Autowired
+    private CompanyNameUtils companyNameUtils;
+
+    public Item getItemFromDisqualification(Disqualification disqualification, StreamData data) {
+        Item item = new Item();
+
+        Object address = disqualification.getAddress();
+        item.setAddress(address);
+        item.setFullAddress(addressUtils.getAddressAsString(address));
+
+        item.setCorporateName(data.getName());
+        CompanyName companyName = companyNameUtils.splitCompanyName(data.getName());
+        item.setCorporateStart(companyName.getName());
+        item.setCorporateEnding(companyName.getEnding());
+
+        item.setDisqualifiedFrom(disqualification.getDisqualifiedFrom());
+        item.setDisqualifiedUntil(disqualification.getDisqualifiedUntil());
+
+        item.setForename(data.getForename());
+        item.setSurname(data.getSurname());
+        item.setOtherForenames(data.getOtherForenames());
+
+        DisqualifiedPersonName personName = new DisqualifiedPersonName(
+                data.getTitle(), data.getForename(), data.getOtherForenames(), data.getSurname());
+        item.setPersonTitleName(personName.getPersonTitleName());
+        item.setPersonName(personName.getPersonName());
+        item.setRecordType(recordType);
+        item.setWildcardKey(personName.getWildcardKey());
+        return item;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformer.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.transformer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.disqualification.DateOfBirth;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.StreamData;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+@Component
+public class ElasticSearchTransformer {
+
+    @Autowired
+    private StreamDataTransformer streamDataTransformer;
+    @Autowired
+    private DisqualificationItemTransformer disqualificationItemTransformer;
+
+    public OfficerDisqualification getOfficerDisqualificationFromResourceChanged(ResourceChangedData data) {
+        StreamData streamData = streamDataTransformer.getStreamDataFromString(data.getData());
+        return getOfficerDisqualificationFromStreamData(streamData);
+    }
+
+    private OfficerDisqualification getOfficerDisqualificationFromStreamData(StreamData in) {
+        OfficerDisqualification out = new OfficerDisqualification();
+        for(Disqualification disqualification : in.getDisqualifications()) {
+            out.addItemsItem(disqualificationItemTransformer.getItemFromDisqualification(disqualification, in));
+        }
+        out.setDateOfBirth(getDateOfBirth(in));
+        out.setLinks(in.getLinks());
+        out.setKind(in.getKind());
+        out.setSortKey(out.getItems().get(0).getWildcardKey());
+        return out;
+    }
+
+    private DateOfBirth getDateOfBirth(StreamData in) {
+        String[] dateParts = in.getDateOfBirth().split("-");
+        DateOfBirth dateOfBirth = new DateOfBirth();
+        dateOfBirth.setYear(dateParts[0]);
+        dateOfBirth.setMonth(dateParts[1]);
+        dateOfBirth.setDay(dateParts[2]);
+        return dateOfBirth;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/StreamDataTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/StreamDataTransformer.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.transformer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.StreamData;
+
+@Component
+public class StreamDataTransformer {
+
+    public StreamData getStreamDataFromString(String data) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.readValue(data, StreamData.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/AddressUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/AddressUtils.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.common.Address;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+public class AddressUtils {
+
+    public String getAddressAsString(Object address) {
+
+        Address a = new ObjectMapper().convertValue(address, Address.class);
+
+        return Stream.of(a.getCareOf(), a.getPoBox(), getPremiseAddressLine1(a), a.getAddressLine2(),
+                a.getLocality(), a.getRegion(), a.getCountry(), a.getPostalCode())
+                .filter(AddressUtils::checkString)
+                .collect(Collectors.joining(", "));
+    }
+
+    private String getPremiseAddressLine1(Address a) {
+        String premises = a.getPremises();
+        String addressLine1 = a.getAddressLine1();
+
+        if (! checkString(premises)) return addressLine1;
+        else if (! checkString(addressLine1)) return premises;
+        else {
+            if (premises.matches("^\\d+$")) {
+                return premises + " " + addressLine1;
+            } else {
+                return premises + ", " + addressLine1;
+            }
+        }
+    }
+
+    private static boolean checkString(String s) {
+        return s != null && s.length() > 0;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/CompanyNameUtils.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/CompanyNameUtils.java
@@ -1,0 +1,101 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.utils;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.CompanyName;
+
+import java.util.regex.Pattern;
+
+@Component
+public class CompanyNameUtils {
+
+    public CompanyName splitCompanyName(String name) {
+        String cname = name;
+        String end = "";
+        for (String ending : nameEndings) {
+            Pattern pattern = Pattern.compile("\\s" + ending + "$", Pattern.CASE_INSENSITIVE);
+            if (pattern.matcher(name).find() && ending.length() > end.length()) {
+                cname = name.substring(0, name.length() - ending.length() - 1);
+                end = name.substring(name.length() - ending.length());
+            }
+        }
+        return new CompanyName(cname, end);
+    }
+
+    // Taken from CH-CompanyNameEndings
+    private final static String[] nameEndings = {
+            "AEIE",
+            "ANGHYFYNGEDIG",
+            "C.B.C",
+            "C.C.C",
+            "C.I.C",
+            "CBC",
+            "CBCN",
+            "CBP",
+            "CCC",
+            "CCG CYF",
+            "CCG CYFYNGEDIG",
+            "CIC",
+            "COMMUNITY INTEREST COMPANY",
+            "COMMUNITY INTEREST P.L.C",
+            "COMMUNITY INTEREST PLC",
+            "COMMUNITY INTEREST PUBLIC LIMITED COMPANY",
+            "CWMNI BUDDIANT C.C.C",
+            "CWMNI BUDDIANT CCC",
+            "CWMNI BUDDIANT CYMUNEDOL C.C.C",
+            "CWMNI BUDDIANT CYMUNEDOL CCC",
+            "CWMNI BUDDIANT CYMUNEDOL CYHOEDDUS CYFYNGEDIG",
+            "CWMNI BUDDIANT CYMUNEDOL",
+            "CWMNI BUDDSODDIA CHYFALAF NEWIDIOL",
+            "CWMNI BUDDSODDIANT PENAGORED",
+            "CWMNI CELL GWARCHODEDIG",
+            "CWMNI CYFYNGEDIG CYHOEDDUS",
+            "CYF",
+            "CYFYNGEDIG",
+            "EEIG",
+            "EESV",
+            "EOFG",
+            "EOOS",
+            "EUROPEAN ECONOMIC INTEREST GROUPING",
+            "GEIE",
+            "GELE",
+            "ICVC",
+            "INVESTMENT COMPANY WITH VARIABLE CAPITAL",
+            "L.P",
+            "L.T.D",
+            "LIMITED - THE",
+            "LIMITED LIABILITY PARTNERSHIP",
+            "LIMITED PARTNERSHIP",
+            "LIMITED THE",
+            "LIMITED",
+            "LIMITED-THE",
+            "LIMITED...THE",
+            "LIMITED..THE",
+            "LIMITED.THE",
+            "LLP",
+            "LP",
+            "LTD",
+            "LTD...THE",
+            "LTD..THE",
+            "LTD.THE",
+            "OEIC",
+            "OPEN-ENDED INVESTMENT COMPANY",
+            "P.L.C",
+            "PAC",
+            "PARTNERIAETH ATEBOLRWYDD CYFYNGEDIG",
+            "PARTNERIAETH CYFYNGEDIG",
+            "PCC LIMITED",
+            "PCC LTD",
+            "PCC",
+            "PLC",
+            "PROTECTED CELL COMPANY",
+            "PUBLIC LIMITED COMPANY .THE",
+            "PUBLIC LIMITED COMPANY THE",
+            "PUBLIC LIMITED COMPANY",
+            "PUBLIC LIMITED COMPANY.THE",
+            "SE",
+            "UKEIG",
+            "UK SOCIETAS",
+            "UNLIMITED",
+            "UNLTD"
+    };
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/DisqualifiedPersonName.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/DisqualifiedPersonName.java
@@ -1,0 +1,35 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.utils;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DisqualifiedPersonName {
+
+    private String title;
+    private String forename;
+    private String otherForenames;
+    private String surname;
+
+    public DisqualifiedPersonName(String title, String forename, String otherForenames, String surname) {
+        this.title = title;
+        this.forename = forename;
+        this.otherForenames = otherForenames;
+        this.surname = surname;
+    }
+
+    public String getPersonName() {
+        return groupNames(forename, otherForenames, surname);
+    }
+
+    public String getPersonTitleName() {
+        return groupNames(title, forename, otherForenames, surname);
+    }
+
+    public String getWildcardKey() {
+        return groupNames(surname, forename, otherForenames) + "1";
+    }
+
+    private String groupNames(String... nameParts) {
+        return Stream.of(nameParts).filter(s -> s!= null && s.length() > 0).collect(Collectors.joining(" "));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
@@ -1,0 +1,81 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.transformer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.CompanyName;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.StreamData;
+import uk.gov.companieshouse.disqualifiedofficers.search.utils.AddressUtils;
+import uk.gov.companieshouse.disqualifiedofficers.search.utils.CompanyNameUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DisqualificationItemTransformerTest {
+
+    private static final String ADDRESS_STRING = "Test Address";
+    private static final String COMPANY_START = "Test";
+    private static final String COMPANY_ENDING = "Limited";
+    private static final String COMPANY_NAME = COMPANY_START + " " + COMPANY_ENDING;
+    private static final LocalDate FROM = LocalDate.of(2022, 1, 1);
+    private static final LocalDate UNTIL = LocalDate.of(2025, 1, 1);
+    private static final Object ADDRESS = new Object();
+    private static final String FORENAME = "forename";
+    private static final String OTHER_FORENAMES = "other";
+    private static final String SURNAME = "surname";
+
+    @Mock
+    AddressUtils addressUtils;
+    @Mock
+    CompanyNameUtils companyNameUtils;
+    @InjectMocks
+    DisqualificationItemTransformer transformer;
+
+    @BeforeEach
+    public void setup() {
+        when(addressUtils.getAddressAsString(ADDRESS)).thenReturn(ADDRESS_STRING);
+        when(companyNameUtils.splitCompanyName(COMPANY_NAME)).thenReturn(new CompanyName(COMPANY_START, COMPANY_ENDING));
+    }
+
+    @Test
+    public void itemIsTransformed() {
+        Item item = transformer.getItemFromDisqualification(getDisqualification(), getData());
+
+        assertThat(item.getCorporateName()).isEqualTo(COMPANY_NAME);
+        assertThat(item.getAddress()).isEqualTo(ADDRESS);
+        assertThat(item.getFullAddress()).isEqualTo(ADDRESS_STRING);
+        assertThat(item.getDisqualifiedFrom()).isEqualTo(FROM);
+        assertThat(item.getDisqualifiedUntil()).isEqualTo(UNTIL);
+        assertThat(item.getForename()).isEqualTo(FORENAME);
+        assertThat(item.getOtherForenames()).isEqualTo(OTHER_FORENAMES);
+        assertThat(item.getSurname()).isEqualTo(SURNAME);
+        assertThat(item.getCorporateStart()).isEqualTo(COMPANY_START);
+        assertThat(item.getCorporateEnding()).isEqualTo(COMPANY_ENDING);
+    }
+
+    private Disqualification getDisqualification() {
+        Disqualification disq = new Disqualification();
+        disq.setAddress(ADDRESS);
+        disq.setDisqualifiedFrom(FROM);
+        disq.setDisqualifiedUntil(UNTIL);
+        return disq;
+    }
+
+    private StreamData getData() {
+        StreamData data = new StreamData();
+        data.setName(COMPANY_NAME);
+        data.setForename(FORENAME);
+        data.setOtherForenames(OTHER_FORENAMES);
+        data.setSurname(SURNAME);
+        return data;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformerTest.java
@@ -1,0 +1,81 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.transformer;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.disqualification.Disqualification;
+import uk.gov.companieshouse.api.disqualification.Item;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.StreamData;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticSearchTransformerTest {
+
+    private static final String DATE_OF_BIRTH = "2000-01-01";
+    private static final String LINK = "Link";
+    private static final String KIND = "Kind";
+    private static final String KEY = "key";
+
+    @Mock
+    DisqualificationItemTransformer itemTransformer;
+    @InjectMocks
+    ElasticSearchTransformer transformer;
+
+    @BeforeEach
+    private void setup() throws Exception {
+        setStreamTransformer();
+        when(itemTransformer.getItemFromDisqualification(
+                any(Disqualification.class), any(StreamData.class))).thenReturn(getItem());
+    }
+
+    @Test
+    public void transformsData() throws Exception {
+        OfficerDisqualification actual = transformer
+                .getOfficerDisqualificationFromResourceChanged(getResourceChangedData());
+
+        assertThat(actual.getDateOfBirth().getDay()).isEqualTo("01");
+        assertThat(actual.getDateOfBirth().getMonth()).isEqualTo("01");
+        assertThat(actual.getDateOfBirth().getYear()).isEqualTo("2000");
+        assertThat(actual.getKind()).isEqualTo(KIND);
+        assertThat(actual.getLinks().getSelf()).isEqualTo(LINK);
+        assertThat(actual.getSortKey()).isEqualTo(KEY);
+        assertThat(actual.getItems().size()).isEqualTo(1);
+        assertThat(actual.getItems().get(0).getWildcardKey()).isEqualTo(KEY);
+    }
+
+    private ResourceChangedData getResourceChangedData() throws Exception {
+        String streamData = new JSONObject()
+                .put("date_of_birth", DATE_OF_BIRTH)
+                .put("disqualifications", new JSONArray().put(new JSONObject()))
+                .put("links", new JSONObject().put("self", LINK))
+                .put("kind", KIND)
+                .toString();
+        ResourceChangedData data = new ResourceChangedData();
+        data.setData(streamData);
+        return data;
+    }
+
+    private Item getItem() {
+        Item item = new Item();
+        item.setWildcardKey(KEY);
+        return item;
+    }
+
+    private void setStreamTransformer() throws Exception {
+        Field privateField = transformer.getClass().getDeclaredField("streamDataTransformer");
+        privateField.setAccessible(true);
+        privateField.set(transformer, new StreamDataTransformer());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/AddressUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/AddressUtilsTest.java
@@ -1,0 +1,85 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.utils;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AddressUtilsTest {
+
+    private String careOf = "care of";
+    private String poBox = "po box";
+    private String premise = "100";
+    private String addressLine1 = "addressLine1";
+    private String addressLine2 = "addressLine2";
+    private String locality = "locality";
+    private String region = "region";
+    private String country = "country";
+    private String postalCode = "postcode";
+
+    private AddressUtils utils = new AddressUtils();
+
+    @Test
+    public void getAddressAsStringReturnAddressStringNumberPremise() throws Exception {
+        Object address = getAddress();
+
+        String addressLine = utils.getAddressAsString(address);
+
+        assertThat(addressLine).isEqualTo(careOf + ", " + poBox + ", " + premise + " "
+                + addressLine1 + ", " + addressLine2 + ", " + locality + ", " + region
+                + ", " + country + ", " + postalCode);
+    }
+
+    @Test
+    public void getAddressAsStringReturnAddressStringWordPremise() throws Exception {
+        premise = "Test";
+        Object address = getAddress();
+
+        String addressLine = utils.getAddressAsString(address);
+
+        assertThat(addressLine).isEqualTo(careOf + ", " + poBox + ", " + premise + ", "
+                + addressLine1 + ", " + addressLine2 + ", " + locality + ", " + region
+                + ", " + country + ", " + postalCode);
+    }
+
+    @Test
+    public void getAddressAsStringReturnAddressStringNoPremise() throws Exception {
+        premise = "";
+        Object address = getAddress();
+
+        String addressLine = utils.getAddressAsString(address);
+
+        assertThat(addressLine).isEqualTo(careOf + ", " + poBox + ", "
+                + addressLine1 + ", " + addressLine2 + ", " + locality + ", " + region
+                + ", " + country + ", " + postalCode);
+    }
+
+    @Test
+    public void getAddressAsStringReturnAddressStringNoAddressLine1() throws Exception {
+        addressLine1 = "";
+        Object address = getAddress();
+
+        String addressLine = utils.getAddressAsString(address);
+
+        assertThat(addressLine).isEqualTo(careOf + ", " + poBox + ", " + premise
+                + ", " + addressLine2 + ", " + locality + ", " + region
+                + ", " + country + ", " + postalCode);
+    }
+
+    private Object getAddress() throws Exception {
+        String json = new JSONObject()
+                .put("care_of", careOf)
+                .put("po_box", poBox)
+                .put("premises", premise)
+                .put("address_line_1", addressLine1)
+                .put("address_line_2", addressLine2)
+                .put("locality", locality)
+                .put("region", region)
+                .put("country", country)
+                .put("postal_code", postalCode)
+                .toString();
+
+        return new ObjectMapper().readValue(json, Object.class);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/CompanyNameUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/CompanyNameUtilsTest.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.disqualifiedofficers.search.model.CompanyName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompanyNameUtilsTest {
+
+    private CompanyNameUtils utils = new CompanyNameUtils();
+
+    @Test
+    public void companyNameSplitCorrectly() {
+        String name = "Test Limited";
+
+        CompanyName companyName = utils.splitCompanyName(name);
+
+        assertThat(companyName.getName()).isEqualTo("Test");
+        assertThat(companyName.getEnding()).isEqualTo("Limited");
+    }
+
+    @Test
+    public void companyNameWithoutSpaceNotSplit() {
+        String name = "TestLimited";
+
+        CompanyName companyName = utils.splitCompanyName(name);
+
+        assertThat(companyName.getName()).isEqualTo("TestLimited");
+        assertThat(companyName.getEnding()).isEqualTo("");
+    }
+
+    @Test
+    public void companyNameWithLargerEndSplitCorrectly() {
+        String name = "Test CWMNI BUDDIANT CYMUNEDOL C.C.C";
+
+        CompanyName companyName = utils.splitCompanyName(name);
+
+        assertThat(companyName.getName()).isEqualTo("Test");
+        assertThat(companyName.getEnding()).isEqualTo("CWMNI BUDDIANT CYMUNEDOL C.C.C");
+    }
+
+    @Test
+    public void companyNameWithLargerEndSplitCorrectlyShortAfterLongInArray() {
+        String name = "Test COMMUNITY INTEREST PLC";
+
+        CompanyName companyName = utils.splitCompanyName(name);
+
+        assertThat(companyName.getName()).isEqualTo("Test");
+        assertThat(companyName.getEnding()).isEqualTo("COMMUNITY INTEREST PLC");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/DisqualifiedPersonNameTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/utils/DisqualifiedPersonNameTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DisqualifiedPersonNameTest {
+
+    private static final String TITLE = "title";
+    private static final String FORENAME = "forename";
+    private static final String OTHER_FORENAMES = "other";
+    private static final String SURNAME = "surname";
+
+    @Test
+    public void disqualifiedPersonNameReturnsCorrectNames() {
+        DisqualifiedPersonName name = new DisqualifiedPersonName(TITLE, FORENAME, OTHER_FORENAMES, SURNAME);
+
+        assertThat(name.getPersonName()).isEqualTo(FORENAME + " " + OTHER_FORENAMES + " " + SURNAME);
+        assertThat(name.getPersonTitleName()).isEqualTo(TITLE + " " + FORENAME + " " + OTHER_FORENAMES + " " + SURNAME);
+        assertThat(name.getWildcardKey()).isEqualTo(SURNAME + " " + FORENAME + " " + OTHER_FORENAMES + "1");
+    }
+
+    @Test
+    public void disqualifiedPersonNameWithNoTitleReturnsCorrectNames() {
+        DisqualifiedPersonName name = new DisqualifiedPersonName("", FORENAME, OTHER_FORENAMES, SURNAME);
+
+        assertThat(name.getPersonName()).isEqualTo(FORENAME + " " + OTHER_FORENAMES + " " + SURNAME);
+        assertThat(name.getPersonTitleName()).isEqualTo(FORENAME + " " + OTHER_FORENAMES + " " + SURNAME);
+        assertThat(name.getWildcardKey()).isEqualTo(SURNAME + " " + FORENAME + " " + OTHER_FORENAMES + "1");
+    }
+
+    @Test
+    public void disqualifiedPersonNameWithNullTitleReturnsCorrectNames() {
+        DisqualifiedPersonName name = new DisqualifiedPersonName(null, FORENAME, OTHER_FORENAMES, SURNAME);
+
+        assertThat(name.getPersonName()).isEqualTo(FORENAME + " " + OTHER_FORENAMES + " " + SURNAME);
+        assertThat(name.getPersonTitleName()).isEqualTo(FORENAME + " " + OTHER_FORENAMES + " " + SURNAME);
+        assertThat(name.getWildcardKey()).isEqualTo(SURNAME + " " + FORENAME + " " + OTHER_FORENAMES + "1");
+    }
+
+    @Test
+    public void disqualifiedPersonNameWithNoOtherForenamesReturnsCorrectNames() {
+        DisqualifiedPersonName name = new DisqualifiedPersonName(TITLE, FORENAME, "", SURNAME);
+
+        assertThat(name.getPersonName()).isEqualTo(FORENAME + " " + SURNAME);
+        assertThat(name.getPersonTitleName()).isEqualTo(TITLE + " " + FORENAME + " " + SURNAME);
+        assertThat(name.getWildcardKey()).isEqualTo(SURNAME + " " + FORENAME + "1");
+    }
+}


### PR DESCRIPTION
This pr adds the elastic search transformer class which takes the data sent by the streaming service, and transforms it into the object required by the search api. The functionality is modelled on the transformation done in chs-backend. Included in this pr are utility classes to handle creating the additional fields required by the elastic search that do not currently exist in the data.

**Resolves:**
- DSND-820