### PR TITLE
Add put request and response handling to search consumer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/exception/NonRetryableErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/exception/NonRetryableErrorException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.exception;
+
+public class NonRetryableErrorException extends RuntimeException {
+    public NonRetryableErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/exception/RetryableErrorException.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/exception/RetryableErrorException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.exception;
+
+public class RetryableErrorException extends RuntimeException {
+    public RetryableErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/handler/ApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/handler/ApiResponseHandler.java
@@ -1,0 +1,37 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.handler;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.RetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+
+public class ApiResponseHandler {
+
+    /**
+     * Handle responses by logging result and throwing any exceptions.
+     */
+    public void handleResponse(
+            final ResponseStatusException ex,
+            final HttpStatus httpStatus,
+            final String logContext,
+            final String msg,
+            final Map<String, Object> logMap,
+            Logger logger)
+            throws NonRetryableErrorException, RetryableErrorException {
+        logMap.put("status", httpStatus.toString());
+        if (HttpStatus.BAD_REQUEST == httpStatus) {
+            // 400 BAD REQUEST status cannot be retried
+            logger.errorContext(logContext, msg, null, logMap);
+            throw new NonRetryableErrorException(msg);
+        } else if (httpStatus.is4xxClientError() || httpStatus.is5xxServerError()) {
+            // any other client or server status can be retried
+            logger.errorContext(logContext, msg + ", retry", null, logMap);
+            throw new RetryableErrorException(msg);
+        } else {
+            logger.debugContext(logContext, msg, logMap);
+        }
+    }
+    
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/handler/ApiResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/handler/ApiResponseHandler.java
@@ -2,11 +2,13 @@ package uk.gov.companieshouse.disqualifiedofficers.search.handler;
 
 import java.util.Map;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.disqualifiedofficers.search.exception.NonRetryableErrorException;
 import uk.gov.companieshouse.disqualifiedofficers.search.exception.RetryableErrorException;
 import uk.gov.companieshouse.logging.Logger;
 
+@Component
 public class ApiResponseHandler {
 
     /**

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
@@ -51,7 +51,7 @@ public class ResourceChangedProcessor {
             OfficerDisqualification elasticSearchData = transformer
                     .getOfficerDisqualificationFromResourceChanged(payload);
 
-            String officerId = Stream.of( elasticSearchData.getLinks().getSelf() )
+            String officerId = Stream.of( elasticSearchData.getLinks().getSelf().split("/") )
                     .reduce( (first,last) -> last ).get();
 
             final ApiResponse<Void> response =

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
@@ -25,6 +25,7 @@ public class ResourceChangedProcessor {
     private final ElasticSearchTransformer transformer;
     private final ApiClientService apiService;
     private final Logger logger;
+    private final ApiResponseHandler apiResponseHandler;
 
     /**
      * Constructor for the changed resource processor.
@@ -34,10 +35,11 @@ public class ResourceChangedProcessor {
      */
     @Autowired
     public ResourceChangedProcessor(ElasticSearchTransformer transformer, Logger logger, 
-            ApiClientService apiService) {
+            ApiClientService apiService, ApiResponseHandler apiResponseHandler) {
         this.transformer = transformer;
         this.apiService = apiService;
         this.logger = logger;
+        this.apiResponseHandler = apiResponseHandler;
     }
 
     public void processResourceChanged(Message<ResourceChangedData> message) {
@@ -60,7 +62,6 @@ public class ResourceChangedProcessor {
                     String.format("Process disqualification for officer with id [%s]", officerId),
                     null);
 
-            ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
             apiResponseHandler.handleResponse(null, HttpStatus.valueOf(response.getStatusCode()),
                     logContext,"Response received from search api", logMap, logger);
         } catch (RetryableErrorException ex) {

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessor.java
@@ -1,24 +1,104 @@
 package uk.gov.companieshouse.disqualifiedofficers.search.processor;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
+
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.RetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.search.service.api.ApiClientService;
 import uk.gov.companieshouse.disqualifiedofficers.search.transformer.ElasticSearchTransformer;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.stream.ResourceChangedData;
 
 @Component
 public class ResourceChangedProcessor {
 
+    private final ElasticSearchTransformer transformer;
+    private final ApiClientService apiService;
+    private final Logger logger;
+
+    /**
+     * Constructor for the changed resource processor.
+     * @param transformer transforms the incoming payload message to an elastic search object
+     * @param logger logs out messages to the app logs
+     * @param apiService handles PUT request to the search api
+     */
     @Autowired
-    private ElasticSearchTransformer transformer;
+    public ResourceChangedProcessor(ElasticSearchTransformer transformer, Logger logger, 
+            ApiClientService apiService) {
+        this.transformer = transformer;
+        this.apiService = apiService;
+        this.logger = logger;
+    }
 
     public void processResourceChanged(Message<ResourceChangedData> message) {
-        ResourceChangedData payload = message.getPayload();
+        try {
+            final Map<String, Object> logMap = new HashMap<>();
+            ResourceChangedData payload = message.getPayload();
+            final String logContext = payload.getContextId();
 
-        OfficerDisqualification elasticSearchData = transformer
-                .getOfficerDisqualificationFromResourceChanged(payload);
 
-        //apiService.sendElasticSearchData(elasticSearchData);
+            OfficerDisqualification elasticSearchData = transformer
+                    .getOfficerDisqualificationFromResourceChanged(payload);
+
+            String officerId = Stream.of( elasticSearchData.getLinks().getSelf() )
+                    .reduce( (first,last) -> last ).get();
+
+            final ApiResponse<Void> response =
+                    apiService.putDisqualificationSearch(logContext, officerId, elasticSearchData);
+            logger.infoContext(
+                    logContext,
+                    String.format("Process disqualification for officer with id [%s]", officerId),
+                    null);
+            handleResponse(null, HttpStatus.valueOf(response.getStatusCode()),
+                    logContext,"Response received from search api", logMap, logger);
+        } catch (RetryableErrorException ex) {
+            retryResourceChangedMessage(message);
+        } catch (Exception ex) {
+            handleErrorMessage(message);
+            // send to error topic
+        }
     }
+
+    public void retryResourceChangedMessage(Message<ResourceChangedData> message) {
+    }
+
+    private void handleErrorMessage(Message<ResourceChangedData> message) {
+    }
+
+    /**
+     * Handle responses by logging result and throwing any exceptions.
+     */
+    public void handleResponse(
+            final ResponseStatusException ex,
+            final HttpStatus httpStatus,
+            final String logContext,
+            final String msg,
+            final Map<String, Object> logMap,
+            Logger logger)
+            throws NonRetryableErrorException, RetryableErrorException {
+        logMap.put("status", httpStatus.toString());
+        if (HttpStatus.BAD_REQUEST == httpStatus) {
+            // 400 BAD REQUEST status cannot be retried
+            logger.errorContext(logContext, msg, null, logMap);
+            throw new NonRetryableErrorException(msg);
+        } else if (httpStatus.is4xxClientError() || httpStatus.is5xxServerError()) {
+            // any other client or server status can be retried
+            logger.errorContext(logContext, msg + ", retry", null, logMap);
+            throw new RetryableErrorException(msg);
+        } else {
+            logger.debugContext(logContext, msg, logMap);
+        }
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientService.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.service.api;
+
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.api.model.ApiResponse;
+
+/**
+ * The {@code ApiClientService} interface provides an abstraction that can be
+ * used when testing {@code ApiClientManager} static methods, without imposing
+ * the use of a test framework that supports mocking of static methods.
+ */
+public interface ApiClientService {
+
+    InternalApiClient getApiClient(String contextId);
+
+    /**
+     * Submit disqualification.
+     */
+
+    ApiResponse<Void> putDisqualificationSearch(
+            final String log,
+            final String officerId,
+            final OfficerDisqualification officerDisqualification);
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImpl.java
@@ -1,0 +1,79 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.service.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.api.http.ApiKeyHttpClient;
+import uk.gov.companieshouse.api.http.HttpClient;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+
+/**
+ * Service that sends REST requests via private SDK.
+ */
+@Primary
+@Service
+public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements ApiClientService {
+
+    @Value("${api.search-api-key}")
+    private String chsApiKey;
+
+    @Value("${api.api-url}")
+    private String apiUrl;
+
+    @Value("${api.internal-api-url}")
+    private String internalApiUrl;
+
+    /**
+     * Construct an {@link ApiClientServiceImpl}.
+     *
+     * @param logger the CH logger
+     */
+    @Autowired
+    public ApiClientServiceImpl(final Logger logger) {
+        super(logger);
+    }
+
+    @Override
+    public InternalApiClient getApiClient(String contextId) {
+        InternalApiClient internalApiClient = new InternalApiClient(getHttpClient(contextId));
+        internalApiClient.setBasePath(apiUrl);
+        internalApiClient.setInternalBasePath(internalApiUrl);
+        return internalApiClient;
+    }
+
+    private HttpClient getHttpClient(String contextId) {
+        ApiKeyHttpClient httpClient = new ApiKeyHttpClient(chsApiKey);
+        httpClient.setRequestId(contextId);
+        return httpClient;
+    }
+
+    @Override
+    public ApiResponse<Void> putDisqualificationSearch(final String log, String officerId,
+            OfficerDisqualification officerDisqualification) {
+        final String uri = String.format("/disqualified-search/disqualified-officers/%s", officerId);
+
+        Map<String, Object> logMap = createLogMap(officerId, "PUT", uri);
+        logger.infoContext(log, String.format("PUT %s", uri), logMap);
+
+        return executeOp(log, "putDisqualificationSearch", uri,
+                getApiClient(log).privateSearchUpsertHandler()
+                        .putSearchDisqualification()
+                        .upsert(uri, officerDisqualification));
+    }
+
+    private Map<String, Object> createLogMap(String officerId, String method, String path) {
+        final Map<String, Object> logMap = new HashMap<>();
+        logMap.put("officer_id", officerId);
+        logMap.put("method", method);
+        logMap.put("path", path);
+        return logMap;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/BaseApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/BaseApiClientServiceImpl.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.service.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.Executor;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+public abstract class BaseApiClientServiceImpl {
+    protected Logger logger;
+
+    protected BaseApiClientServiceImpl(final Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * General execution of an SDK endpoint.
+     *
+     * @param <T>           type of api response
+     * @param logContext    context ID for logging
+     * @param operationName name of operation
+     * @param uri           uri of sdk being called
+     * @param executor      executor to use
+     * @return the response object
+     */
+    public <T> ApiResponse<T> executeOp(final String logContext,
+                                        final String operationName,
+                                        final String uri,
+                                        final Executor<ApiResponse<T>> executor) {
+
+        final Map<String, Object> logMap = new HashMap<>();
+        logMap.put("operation_name", operationName);
+        logMap.put("path", uri);
+
+        try {
+
+            return executor.execute();
+
+        } catch (URIValidationException ex) {
+            logger.errorContext(logContext, "SDK exception", ex, logMap);
+
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        } catch (ApiErrorResponseException ex) {
+            logMap.put("status", ex.getStatusCode());
+            logger.errorContext(logContext, "SDK exception", ex, logMap);
+
+            throw new ResponseStatusException(HttpStatus.valueOf(ex.getStatusCode()),
+                    ex.getStatusMessage(), ex);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
   kafka:
     bootstrap-servers: ${STREAMING_KAFKA_BROKER_URL:localhost:29092}
 
+api:
+  search-api-key: ${SEARCH_API_KEY:localhost}
+  api-url: ${API_URL:http://localhost:8888}
+  internal-api-url: ${INTERNAL_API_URL:localhost}
+
 disqualified-officers:
   search:
     group-id: disqualified-officers-search-consumer

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/handler/ApiResponseHandlerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/handler/ApiResponseHandlerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.handler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.RetryableErrorException;
+import uk.gov.companieshouse.logging.Logger;
+import java.util.HashMap;
+import java.util.Map;
+import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertThrows;
+
+
+@ExtendWith(MockitoExtension.class)
+class ApiResponseHandlerTest {
+
+    private ApiResponseHandler apiResponseHandler = new ApiResponseHandler();
+
+    @Mock
+    private Logger logger;
+    @Mock
+    ResponseStatusException ex;
+
+    @Test
+    void handle200Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.OK;
+        Map<String, Object> logMap = new HashMap<>();
+
+        apiResponseHandler.handleResponse(
+                ex, httpStatus,"status", "testy test test", logMap, logger );
+        verify(logger).debugContext("status", "testy test test", logMap);
+    }
+
+    @Test
+    void handleBadResponse() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(NonRetryableErrorException.class, () -> apiResponseHandler.handleResponse(
+                ex, httpStatus, "status", "testy test test", logMap, logger));
+        verify(logger).errorContext("status", "testy test test", null, logMap);
+    }
+
+    @Test
+    void handle500Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(RetryableErrorException.class, () -> apiResponseHandler.handleResponse(
+                ex, httpStatus, "status", "testy test test", logMap, logger));
+        verify(logger).errorContext("status", "testy test test, retry", null, logMap);
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessorTest.java
@@ -14,6 +14,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import uk.gov.companieshouse.api.disqualification.DisqualificationLinks;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.disqualifiedofficers.search.handler.ApiResponseHandler;
 import uk.gov.companieshouse.disqualifiedofficers.search.service.api.ApiClientService;
 import uk.gov.companieshouse.disqualifiedofficers.search.transformer.ElasticSearchTransformer;
 import uk.gov.companieshouse.logging.Logger;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 public class ResourceChangedProcessorTest {
 
     private ResourceChangedProcessor resourceChangedProcessor;
+    private ApiResponseHandler apiResponseHandler;
     @Mock
     private ElasticSearchTransformer transformer;
     @Mock
@@ -41,10 +43,12 @@ public class ResourceChangedProcessorTest {
 
     @BeforeEach
     void setUp() {
+        apiResponseHandler = new ApiResponseHandler();
         resourceChangedProcessor = new ResourceChangedProcessor(
                 transformer,
                 logger,
-                apiClientService
+                apiClientService,
+                apiResponseHandler
         );
     }
 

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/processor/ResourceChangedProcessorTest.java
@@ -1,0 +1,122 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.processor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.NonRetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.search.exception.RetryableErrorException;
+import uk.gov.companieshouse.disqualifiedofficers.search.service.api.ApiClientService;
+import uk.gov.companieshouse.disqualifiedofficers.search.transformer.ElasticSearchTransformer;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.stream.EventRecord;
+import uk.gov.companieshouse.stream.ResourceChangedData;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ResourceChangedProcessorTest {
+
+    private ResourceChangedProcessor resourceChangedProcessor;
+    @Mock
+    private ElasticSearchTransformer transformer;
+    @Mock
+    private Logger logger;
+    @Mock
+    private ApiClientService apiClientService;
+    @Mock
+    ResponseStatusException ex;
+
+
+    @BeforeEach
+    void setUp() {
+        resourceChangedProcessor = new ResourceChangedProcessor(
+                transformer,
+                logger,
+                apiClientService
+        );
+    }
+
+    @Test
+    @DisplayName("Transforms a kafka message containing a payload into a search api object")
+    void When_ValidMessage_Expect_ValidDisqualificationES6Mapping() throws IOException {
+        Message<ResourceChangedData> mockChsResourceChangedData = createChsMessage();
+        when(transformer.getOfficerDisqualificationFromResourceChanged(
+                mockChsResourceChangedData.getPayload())).thenCallRealMethod();
+
+        resourceChangedProcessor.processResourceChanged(mockChsResourceChangedData);
+
+        verify(transformer).getOfficerDisqualificationFromResourceChanged(mockChsResourceChangedData.getPayload());
+    }
+
+    private Message<ResourceChangedData> createChsMessage() throws IOException {
+        InputStreamReader exampleJsonPayload = new InputStreamReader(
+                ClassLoader.getSystemClassLoader().getResourceAsStream("disqualified-officers-example.json"));
+        String data = FileCopyUtils.copyToString(exampleJsonPayload);
+
+        EventRecord eventRecord = new EventRecord();
+        eventRecord.setPublishedAt("2022010351");
+        eventRecord.setType("changed");
+        
+        String officerId = "1234567890";
+
+        ResourceChangedData mockChsResourceChangedData = ResourceChangedData.newBuilder()
+                .setData(data)
+                .setContextId("context_id")
+                .setResourceId(officerId)
+                .setResourceKind("disqualified-officers")
+                .setResourceUri(String.format("/disqualified-officers/natural/%s", officerId))
+                .setEvent(eventRecord)
+                .build();
+
+        return MessageBuilder
+                .withPayload(mockChsResourceChangedData)
+                .setHeader(KafkaHeaders.RECEIVED_TOPIC, "test")
+                .setHeader("CHANGED_RESOURCE_RETRY_COUNT", 1)
+                .build();
+    }
+
+    @Test
+    void handle200Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.OK;
+        Map<String, Object> logMap = new HashMap<>();
+
+        resourceChangedProcessor.handleResponse(
+                ex, httpStatus,"status", "testy test test", logMap, logger );
+        verify(logger).debugContext("status", "testy test test", logMap);
+    }
+
+    @Test
+    void handleBadResponse() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(NonRetryableErrorException.class, () -> resourceChangedProcessor.handleResponse(
+                ex, httpStatus, "status", "testy test test", logMap, logger));
+        verify(logger).errorContext("status", "testy test test", null, logMap);
+    }
+
+    @Test
+    void handle500Response() throws NonRetryableErrorException, RetryableErrorException {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        Map<String, Object> logMap = new HashMap<>();
+        assertThrows(RetryableErrorException.class, () -> resourceChangedProcessor.handleResponse(
+                ex, httpStatus, "status", "testy test test", logMap, logger));
+        verify(logger).errorContext("status", "testy test test, retry", null, logMap);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
@@ -29,7 +29,7 @@ public class ResourceChangedSerializerTest {
     }
 
     @Test
-    void When_serialize_Expect_chsDeltaBytes() throws Exception {
+    void When_serialize_Expect_ChangedReourceBytes() throws Exception {
         EventRecord eventRecord = new EventRecord("published_at", "type", List.of("fields_changed"));
         ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind",
                 "resource_uri", "context_id", "resource_id", "data", eventRecord );

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/serialization/ResourceChangedSerializerTest.java
@@ -29,7 +29,7 @@ public class ResourceChangedSerializerTest {
     }
 
     @Test
-    void When_serialize_Expect_ChangedReourceBytes() throws Exception {
+    void When_serialize_Expect_ChangedResourceBytes() throws Exception {
         EventRecord eventRecord = new EventRecord("published_at", "type", List.of("fields_changed"));
         ResourceChangedData resourceChangedData = new ResourceChangedData("resource_kind",
                 "resource_uri", "context_id", "resource_id", "data", eventRecord );

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImplTest.java
@@ -1,0 +1,60 @@
+package uk.gov.companieshouse.disqualifiedofficers.search.service.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.search.disqualification.request.PrivateOfficerDisqualificationSearchUpsert;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ApiClientServiceImplTest {
+
+    @Mock
+    Logger logger;
+
+    private ApiClientServiceImpl apiClientService;
+
+    @BeforeEach
+    void setup() {
+        apiClientService = new ApiClientServiceImpl(logger);
+        ReflectionTestUtils.setField(apiClientService, "chsApiKey", "apiKey");
+        ReflectionTestUtils.setField(apiClientService, "apiUrl", "https://api.companieshouse.gov.uk");
+    }
+
+    @Test
+    void putDisqualificationSearch() throws ApiErrorResponseException, URIValidationException {
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PrivateOfficerDisqualificationSearchUpsert.class));
+
+        ApiResponse<Void> response = apiClientServiceSpy.putDisqualificationSearch("context_id",
+                "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==",
+                new OfficerDisqualification());
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("putDisqualificationSearch"),
+                eq("/disqualified-search/disqualified-officers/" +
+                        "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA=="),
+                any(PrivateOfficerDisqualificationSearchUpsert.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
+
+    }
+}

--- a/src/test/resources/disqualified-officers-example.json
+++ b/src/test/resources/disqualified-officers-example.json
@@ -1,0 +1,62 @@
+{
+    "company_number": "string", 
+    "country_of_registration": "string", 
+    "date_of_birth": "12-02-1995", 
+    "disqualifications": [
+        {
+            "address": {
+                "address_line_1": "string",
+                "address_line_2": "string",
+                "country": "string",
+                "locality": "string",
+                "postal_code": "string",
+                "premises": "string",
+                "region": "string"
+            },
+            "case_identifier": "string",
+            "company_names": [
+                "string"
+            ],
+            "court_name": "string",
+            "disqualification_type": "string",
+            "disqualified_from": "12-02-2022",
+            "disqualified_until": "12-02-2023",
+            "heard_on": "12-01-2022",
+            "last_variation": [
+                {
+                    "case_identifier": "string",
+                    "court_name": "string",
+                    "varied_on": "10-02-2022"
+                }
+            ],
+            "reason": {
+                "act": "string",
+                "article": "string",
+                "description_identifier": "string"
+            },
+            "undertaken_on": "12-02-2022"
+        }
+    ],
+    "etag": "string",
+    "forename": "string",
+    "honours": "string",
+    "kind": "string",
+    "links": {
+        "self": "string"
+    },
+    "name": "string", 
+    "nationality": "string", 
+    "other_forenames": "string", 
+    "permissions_to_act": [
+        {
+            "company_names": [
+                "string"
+            ],
+            "court_name": "string",
+            "expires_on": "12-02-2023",
+            "granted_on": "12-02-2022"
+        }
+    ],
+    "surname": "string",
+    "title": "string"
+}


### PR DESCRIPTION
This PR sends a put request from the search consumer to the search api after the successful transformation of a ResourceChanged disqualified officer message. It also handles non-200 responses from the api and either sends a retry message or throws a non-retryable error depending on the response.

**Resolves**
DSND-693