### PR TITLE
Use a string for the disqualified dates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <kafka-models.version>1.0.27</kafka-models.version>
         <ch-kafka.version>1.4.4</ch-kafka.version>
         <structured-logging.version>1.9.12</structured-logging.version>
-        <private-api-sdk-java.version>2.0.162</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.164</private-api-sdk-java.version>
         <test-containers.version>1.16.2</test-containers.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformer.java
@@ -10,6 +10,8 @@ import uk.gov.companieshouse.disqualifiedofficers.search.utils.AddressUtils;
 import uk.gov.companieshouse.disqualifiedofficers.search.utils.CompanyNameUtils;
 import uk.gov.companieshouse.disqualifiedofficers.search.utils.DisqualifiedPersonName;
 
+import java.time.format.DateTimeFormatter;
+
 @Component
 public class DisqualificationItemTransformer {
 
@@ -32,8 +34,11 @@ public class DisqualificationItemTransformer {
         item.setCorporateStart(companyName.getName());
         item.setCorporateEnding(companyName.getEnding());
 
-        item.setDisqualifiedFrom(disqualification.getDisqualifiedFrom());
-        item.setDisqualifiedUntil(disqualification.getDisqualifiedUntil());
+        DateTimeFormatter dateTimeFormatter =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        item.setDisqualifiedFrom(disqualification.getDisqualifiedFrom().format(dateTimeFormatter));
+        item.setDisqualifiedUntil(disqualification.getDisqualifiedUntil().format(dateTimeFormatter));
 
         item.setForename(data.getForename());
         item.setSurname(data.getSurname());

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
@@ -26,7 +26,9 @@ public class DisqualificationItemTransformerTest {
     private static final String COMPANY_ENDING = "Limited";
     private static final String COMPANY_NAME = COMPANY_START + " " + COMPANY_ENDING;
     private static final LocalDate FROM = LocalDate.of(2022, 1, 1);
+    private static final String FROM_STRING = "2022-01-01";
     private static final LocalDate UNTIL = LocalDate.of(2025, 1, 1);
+    private static final String UNTIL_STRING = "2025-01-01";
     private static final Object ADDRESS = new Object();
     private static final String FORENAME = "forename";
     private static final String OTHER_FORENAMES = "other";
@@ -52,8 +54,8 @@ public class DisqualificationItemTransformerTest {
         assertThat(item.getCorporateName()).isEqualTo(COMPANY_NAME);
         assertThat(item.getAddress()).isEqualTo(ADDRESS);
         assertThat(item.getFullAddress()).isEqualTo(ADDRESS_STRING);
-        assertThat(item.getDisqualifiedFrom()).isEqualTo(FROM);
-        assertThat(item.getDisqualifiedUntil()).isEqualTo(UNTIL);
+        assertThat(item.getDisqualifiedFrom()).isEqualTo(FROM_STRING);
+        assertThat(item.getDisqualifiedUntil()).isEqualTo(UNTIL_STRING);
         assertThat(item.getForename()).isEqualTo(FORENAME);
         assertThat(item.getOtherForenames()).isEqualTo(OTHER_FORENAMES);
         assertThat(item.getSurname()).isEqualTo(SURNAME);


### PR DESCRIPTION
This pr changes the date format sent to the search api to a string to reduce the transformation done in there.