### PR TITLE
Fix corporate sort key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <structured-logging.version>1.9.12</structured-logging.version>
         <private-api-sdk-java.version>2.0.165</private-api-sdk-java.version>
         <test-containers.version>1.16.2</test-containers.version>
-        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>2.12.4</maven-failsafe-plugin.version>
 
         <!-- Docker -->
         <jib-maven-plugin.version>3.1.1</jib-maven-plugin.version>

--- a/src/itest/resources/output/corporate-output.json
+++ b/src/itest/resources/output/corporate-output.json
@@ -12,21 +12,21 @@
       },
       "disqualified_from":"2015-08-13",
       "disqualified_until":"2030-08-12",
-      "wildcard_key":"1",
-      "forename":"",
-      "other_forenames":"",
+      "wildcard_key":null,
+      "forename":null,
+      "other_forenames":null,
       "surname":null,
-      "person_name":"",
+      "person_name":null,
       "full_address":"39 Arnold Gardens, London, London, England, N13 5JE",
       "corporate_name":"KINDNESSLIQUOR",
       "corporate_name_ending":"",
       "corporate_name_start":"KINDNESSLIQUOR",
       "record_type":"disqualifications",
-      "person_title_name":""
+      "person_title_name":null
     }
   ],
   "date_of_birth":null,
-  "sort_key":"1",
+  "sort_key":null,
   "kind":"string",
   "links":{
     "self":"/disqualified-officers/corporate/hv92jMgpl7e-ttvc5yZXqWiuHbQ"

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformer.java
@@ -28,12 +28,10 @@ public class DisqualificationItemTransformer {
         item.setAddress(address);
         item.setFullAddress(addressUtils.getAddressAsString(address));
 
-        item.setCorporateName(data.getName());
-        CompanyName companyName;
-        if (data.getName() != null) {
-            companyName = companyNameUtils.splitCompanyName(data.getName());
-            item.setCorporateNameStart(companyName.getName());
-            item.setCorporateNameEnding(companyName.getEnding());
+        if (data.getName() != null && data.getName().length() > 0) {
+            setCorporateFields(item, data);
+        } else {
+            setPersonFields(item, data);
         }
 
         DateTimeFormatter dateTimeFormatter =
@@ -42,6 +40,19 @@ public class DisqualificationItemTransformer {
         item.setDisqualifiedFrom(disqualification.getDisqualifiedFrom().format(dateTimeFormatter));
         item.setDisqualifiedUntil(disqualification.getDisqualifiedUntil().format(dateTimeFormatter));
 
+        item.setRecordType(recordType);
+
+        return item;
+    }
+
+    private void setCorporateFields(Item item, StreamData data) {
+        item.setCorporateName(data.getName());
+        CompanyName companyName = companyNameUtils.splitCompanyName(data.getName());
+        item.setCorporateNameStart(companyName.getName());
+        item.setCorporateNameEnding(companyName.getEnding());
+    }
+
+    private void setPersonFields(Item item, StreamData data) {
         item.setForename(data.getForename());
         item.setSurname(data.getSurname());
         item.setOtherForenames(data.getOtherForenames());
@@ -50,8 +61,6 @@ public class DisqualificationItemTransformer {
                 data.getTitle(), data.getForename(), data.getOtherForenames(), data.getSurname());
         item.setPersonTitleName(personName.getPersonTitleName());
         item.setPersonName(personName.getPersonName());
-        item.setRecordType(recordType);
         item.setWildcardKey(personName.getWildcardKey());
-        return item;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
@@ -44,14 +44,12 @@ public class DisqualificationItemTransformerTest {
     @BeforeEach
     public void setup() {
         when(addressUtils.getAddressAsString(ADDRESS)).thenReturn(ADDRESS_STRING);
-        when(companyNameUtils.splitCompanyName(COMPANY_NAME)).thenReturn(new CompanyName(COMPANY_START, COMPANY_ENDING));
     }
 
     @Test
-    public void itemIsTransformed() {
-        Item item = transformer.getItemFromDisqualification(getDisqualification(), getData());
+    public void personItemIsTransformed() {
+        Item item = transformer.getItemFromDisqualification(getDisqualification(), getData(true));
 
-        assertThat(item.getCorporateName()).isEqualTo(COMPANY_NAME);
         assertThat(item.getAddress()).isEqualTo(ADDRESS);
         assertThat(item.getFullAddress()).isEqualTo(ADDRESS_STRING);
         assertThat(item.getDisqualifiedFrom()).isEqualTo(FROM_STRING);
@@ -59,8 +57,23 @@ public class DisqualificationItemTransformerTest {
         assertThat(item.getForename()).isEqualTo(FORENAME);
         assertThat(item.getOtherForenames()).isEqualTo(OTHER_FORENAMES);
         assertThat(item.getSurname()).isEqualTo(SURNAME);
+        assertThat(item.getWildcardKey()).isEqualTo(SURNAME + " " + FORENAME + " " + OTHER_FORENAMES + "1");
+    }
+
+    @Test
+    public void corporateItemIsTransformer() {
+        when(companyNameUtils.splitCompanyName(COMPANY_NAME)).thenReturn(new CompanyName(COMPANY_START, COMPANY_ENDING));
+
+        Item item = transformer.getItemFromDisqualification(getDisqualification(), getData(false));
+
+        assertThat(item.getCorporateName()).isEqualTo(COMPANY_NAME);
+        assertThat(item.getAddress()).isEqualTo(ADDRESS);
+        assertThat(item.getFullAddress()).isEqualTo(ADDRESS_STRING);
+        assertThat(item.getDisqualifiedFrom()).isEqualTo(FROM_STRING);
+        assertThat(item.getDisqualifiedUntil()).isEqualTo(UNTIL_STRING);
         assertThat(item.getCorporateNameStart()).isEqualTo(COMPANY_START);
         assertThat(item.getCorporateNameEnding()).isEqualTo(COMPANY_ENDING);
+        assertThat(item.getWildcardKey()).isNull();
     }
 
     private Disqualification getDisqualification() {
@@ -71,12 +84,16 @@ public class DisqualificationItemTransformerTest {
         return disq;
     }
 
-    private StreamData getData() {
+    private StreamData getData(boolean isPerson) {
         StreamData data = new StreamData();
-        data.setName(COMPANY_NAME);
-        data.setForename(FORENAME);
-        data.setOtherForenames(OTHER_FORENAMES);
-        data.setSurname(SURNAME);
+
+        if (isPerson) {
+            data.setForename(FORENAME);
+            data.setOtherForenames(OTHER_FORENAMES);
+            data.setSurname(SURNAME);
+        } else {
+            data.setName(COMPANY_NAME);
+        }
         return data;
     }
 


### PR DESCRIPTION
This pr adds a fix to the transformer so that sort and wildcard key are returned as null for a corporate officer. Also included is a downgrade of the failsafe plugin to avoid a bug in version 3 where cucumber tests aren't run during maven integration test builds.

**Resolves:**
- DSND-888