### PR TITLE
Use hard coded resource kind to match chs-backend

### DIFF
--- a/src/itest/resources/input/corporate-disqualification.json
+++ b/src/itest/resources/input/corporate-disqualification.json
@@ -38,7 +38,6 @@
   "etag": "0fca075379cc57c44970e74a5cfbe4f8be5b20be",
   "forename": "",
   "honours": "",
-  "kind": "string",
   "links": {
     "self": "/disqualified-officers/corporate/hv92jMgpl7e-ttvc5yZXqWiuHbQ"
   },

--- a/src/itest/resources/input/natural-disqualification.json
+++ b/src/itest/resources/input/natural-disqualification.json
@@ -38,7 +38,6 @@
   "etag": "0fca075379cc57c44970e74a5cfbe4f8be5b20be",
   "forename": "Dust",
   "honours": "",
-  "kind": "searchresults#disqualified-officer",
   "links": {
     "self": "/disqualified-officers/natural/hv92jMgpl7e-ttvc5yZXqWiuHbQ"
   },

--- a/src/itest/resources/output/corporate-output.json
+++ b/src/itest/resources/output/corporate-output.json
@@ -27,7 +27,7 @@
   ],
   "date_of_birth":null,
   "sort_key":null,
-  "kind":"string",
+  "kind":"searchresults#disqualified-officer",
   "links":{
     "self":"/disqualified-officers/corporate/hv92jMgpl7e-ttvc5yZXqWiuHbQ"
   }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformer.java
@@ -12,6 +12,8 @@ import uk.gov.companieshouse.stream.ResourceChangedData;
 @Component
 public class ElasticSearchTransformer {
 
+    private static final String RESOURCE_KIND = "searchresults#disqualified-officer";
+
     @Autowired
     private StreamDataTransformer streamDataTransformer;
     @Autowired
@@ -34,7 +36,7 @@ public class ElasticSearchTransformer {
         }
         if (in.getDateOfBirth() != null) out.setDateOfBirth(getDateOfBirth(in));
         out.setLinks(in.getLinks());
-        out.setKind(in.getKind());
+        out.setKind(RESOURCE_KIND);
         out.setSortKey(out.getItems().get(0).getWildcardKey());
         return out;
     }

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/ElasticSearchTransformerTest.java
@@ -29,7 +29,6 @@ public class ElasticSearchTransformerTest {
 
     private static final String DATE_OF_BIRTH = "2000-01-01";
     private static final String LINK = "Link";
-    private static final String KIND = "Kind";
     private static final String KEY = "key";
 
     @Mock
@@ -55,7 +54,7 @@ public class ElasticSearchTransformerTest {
         assertThat(actual.getDateOfBirth().getDay()).isEqualTo("01");
         assertThat(actual.getDateOfBirth().getMonth()).isEqualTo("01");
         assertThat(actual.getDateOfBirth().getYear()).isEqualTo("2000");
-        assertThat(actual.getKind()).isEqualTo(KIND);
+        assertThat(actual.getKind()).isEqualTo("searchresults#disqualified-officer");
         assertThat(actual.getLinks().getSelf()).isEqualTo(LINK);
         assertThat(actual.getSortKey()).isEqualTo(KEY);
         assertThat(actual.getItems().size()).isEqualTo(1);
@@ -87,7 +86,6 @@ public class ElasticSearchTransformerTest {
                 .put("date_of_birth", DATE_OF_BIRTH)
                 .put("disqualifications", new JSONArray().put(new JSONObject()))
                 .put("links", new JSONObject().put("self", LINK))
-                .put("kind", KIND)
                 .toString();
         ResourceChangedData data = new ResourceChangedData();
         data.setData(valid ? streamData : "Invalid");


### PR DESCRIPTION
This pr changes the setting of the kind value to be hard coded to `searchresults#disqualified-officer`. This is to match current functionality seen in chs-backend.