### PR TITLE
Add delete request to search consumer and handle payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <io-cucumber.version>7.2.3</io-cucumber.version>
         <wiremock.standalone.version>2.32.0</wiremock.standalone.version>
         <structured-logging.version>1.9.12</structured-logging.version>
-        <private-api-sdk-java.version>2.0.168</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.178</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
         <test-containers.version>1.16.3</test-containers.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>

--- a/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/steps/DisqualificationSearchSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/disqualifiedofficers/search/steps/DisqualificationSearchSteps.java
@@ -67,7 +67,8 @@ public class DisqualificationSearchSteps {
         this.type = officerType;
         stubSearchApi(200);
         ResourceChangedData data = testData.getResourceChangedData("src/itest/resources/input/" + officerType + "-disqualification.json");
-
+        data.setEvent(new EventRecord("Test", "Test", Arrays.asList("Test", "Test")));
+        data.setResourceId(officerId);
         kafkaTemplate.send(mainTopic, data);
 
         countDown();
@@ -98,6 +99,8 @@ public class DisqualificationSearchSteps {
         stubSearchApi(responseCode);
 
         ResourceChangedData data = testData.getResourceChangedData("src/itest/resources/input/natural-disqualification.json");
+        data.setEvent(new EventRecord("Test", "Test", Arrays.asList("Test", "Test")));
+        data.setResourceId(officerId);
 
         kafkaTemplate.send(mainTopic, data);
 

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientService.java
@@ -16,9 +16,15 @@ public interface ApiClientService {
     /**
      * Submit disqualification.
      */
-
     ApiResponse<Void> putDisqualificationSearch(
             final String log,
             final String officerId,
             final OfficerDisqualification officerDisqualification);
+
+    /**
+     * Delete disqualification.
+     */
+    ApiResponse<Void> deleteDisqualificationSearch(
+            final String log,
+            final String officerId);
 }

--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImpl.java
@@ -64,9 +64,22 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
         logger.infoContext(log, String.format("PUT %s", uri), logMap);
 
         return executeOp(log, "putDisqualificationSearch", uri,
-                getApiClient(log).privateSearchUpsertHandler()
+                getApiClient(log).privateSearchResourceHandler()
                         .putSearchDisqualification()
                         .upsert(uri, officerDisqualification));
+    }
+
+    @Override
+    public ApiResponse<Void> deleteDisqualificationSearch(final String log, String officerId) {
+        final String uri = String.format("/disqualified-search/delete/%s", officerId);
+
+        Map<String, Object> logMap = createLogMap(officerId, "DELETE", uri);
+        logger.infoContext(log, String.format("DELETE %s", uri), logMap);
+
+        return executeOp(log, "deleteDisqualificationSearch", uri,
+                getApiClient(log).privateSearchResourceHandler()
+                        .deleteSearchDisqualification()
+                        .delete(uri));
     }
 
     private Map<String, Object> createLogMap(String officerId, String method, String path) {

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/service/api/ApiClientServiceImplTest.java
@@ -9,8 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.companieshouse.api.disqualification.OfficerDisqualification;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.search.disqualification.request.PrivateOfficerDisqualificationSearchDelete;
 import uk.gov.companieshouse.api.handler.search.disqualification.request.PrivateOfficerDisqualificationSearchUpsert;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
@@ -55,6 +54,23 @@ class ApiClientServiceImplTest {
                 any(PrivateOfficerDisqualificationSearchUpsert.class));
 
         assertThat(response).isEqualTo(expectedResponse);
+    }
 
+    @Test
+    void deleteDisqualificationSearch() {
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PrivateOfficerDisqualificationSearchDelete.class));
+
+        ApiResponse<Void> response = apiClientServiceSpy.deleteDisqualificationSearch("context_id",
+                "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA==");
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("deleteDisqualificationSearch"),
+                eq("/disqualified-search/delete/" +
+                        "ZTgzYWQwODAzMGY1ZDNkNGZiOTAxOWQ1YzJkYzc5MWViMTE3ZjQxZA=="),
+                any(PrivateOfficerDisqualificationSearchDelete.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
     }
 }


### PR DESCRIPTION
Add the ability to send a delete request from the search consumer to the search api when the incoming payload has an event type of deleted.