### PR TITLE
DB-2853 - Add missing person_number field to StreamData

### DIFF
--- a/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/model/StreamData.java
+++ b/src/main/java/uk/gov/companieshouse/disqualifiedofficers/search/model/StreamData.java
@@ -47,6 +47,9 @@ public class StreamData {
     @JsonProperty("title")
     private String title;
 
+    @JsonProperty("person_number")
+    private String personNumber;
+
     // Corporate properties
     @JsonProperty("company_number")
     private String companyNumber;
@@ -163,6 +166,14 @@ public class StreamData {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getPersonNumber() {
+        return personNumber;
+    }
+
+    public void setPersonNumber(String personNumber) {
+        this.personNumber = personNumber;
     }
 
     public void setCompanyNumber(String companyNumber) {

--- a/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/disqualifiedofficers/search/transformer/DisqualificationItemTransformerTest.java
@@ -33,6 +33,7 @@ public class DisqualificationItemTransformerTest {
     private static final String FORENAME = "forename";
     private static final String OTHER_FORENAMES = "other";
     private static final String SURNAME = "surname";
+    private static final String PERSON_NUMBER = "12345678";
 
     @Mock
     AddressUtils addressUtils;
@@ -91,6 +92,7 @@ public class DisqualificationItemTransformerTest {
             data.setForename(FORENAME);
             data.setOtherForenames(OTHER_FORENAMES);
             data.setSurname(SURNAME);
+            data.setPersonNumber(PERSON_NUMBER);
         } else {
             data.setName(COMPANY_NAME);
         }


### PR DESCRIPTION
Fix for error caused by unrecognised field, preventing new disqualified officers from being added to the index.
```Unrecognized field "person_number" (class uk.gov.companieshouse.disqualifiedofficers.search.model.StreamData), not marked as ignorable```