### PR TITLE
Explicitly define maven plugin version to fix errors in pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <java.version>11</java.version>
         <spring.boot.version>2.6.4</spring.boot.version>
+        <spring-boot-maven-plugin.version>2.5.5</spring-boot-maven-plugin.version>
 
         <main.class>uk.gov.companieshouse.disqualifiedofficers.search.DisqualifiedOfficersSearchConsumerApplication</main.class>
 
@@ -238,6 +239,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-maven-plugin.version}</version>
                 <configuration>
                     <mainClass>${main.class}</mainClass>
                 </configuration>


### PR DESCRIPTION
Fixes error `Execution default of goal org.springframework.boot:spring-boot-maven-plugin:3.3.3:repackage failed: Unable to load the mojo 'repackage' in the plugin 'org.springframework.boot:spring-boot-maven-plugin:3.3.3' due to an API incompatibility` that has been happening in pipeline since September 2023.

Successful build can be seen here:
https://ci.platform.aws.chdev.org/teams/team-harmonia/pipelines/disqualified-officers-search-consumer/jobs/analyse-pull-request/builds/9