### PR TITLE
Updated Makefile for dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,6 @@
 artifact_name       := disqualified-officers-search-consumer
 version             := "unversioned"
 
-dependency_check_base_suppressions := common_suppressions_spring_6.xml
-dependency_check_minimum_cvss := 4
-dependency_check_assembly_analyzer_enabled := false
-dependency_check_suppressions_repo_url := git@github.com:companieshouse/dependency-check-suppressions.git
-suppressions_file := target/suppressions.xml
-
 .PHONY: all
 all: build
 
@@ -54,36 +48,9 @@ endif
 dist: clean build package
 
 .PHONY: sonar
-sonar: dependency-check
-	mvn sonar:sonar -Dsonar.dependencyCheck.htmlReportPath=./target/dependency-check-report.html
+sonar:
+	mvn sonar:sonar
 
 .PHONY: sonar-pr-analysis
-sonar-pr-analysis: dependency-check
-	mvn sonar:sonar -P sonar-pr-analysis -Dsonar.dependencyCheck.htmlReportPath=./target/dependency-check-report.html
-
-.PHONY: dependency-check
-dependency-check:
-	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
-		suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
-	fi; \
-	if [ ! -d "$${suppressions_home}" ]; then \
-	    suppressions_home_target_dir="./target/dependency-check-suppressions"; \
-		if [ -d "$${suppressions_home_target_dir}" ]; then \
-			suppressions_home="$${suppressions_home_target_dir}"; \
-		else \
-			mkdir -p "./target"; \
-			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
-				suppressions_home="$${suppressions_home_target_dir}"; \
-		fi; \
-	fi; \
-	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
-	if [  -f "$${suppressions_path}" ]; then \
-		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
-	else \
-		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
-		exit 1; \
-	fi
-
-.PHONY: security-check
-security-check: dependency-check
+sonar-pr-analysis:
+	mvn sonar:sonar -P sonar-pr-analysis

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.11</version>
+        <version>2.1.12</version>
     </parent>
 
     <artifactId>disqualified-officers-search-consumer</artifactId>


### PR DESCRIPTION
removed the dependency check section from the Makefile as a part of migrating to a centralized vulnerability scanning approach managed via the CI pipeline.
Updated parent pom to 2.1.12, use relativePath 2.1.12 brings in updated dependency-check settings.